### PR TITLE
feat: add support for validating role privileges on your own non admin account

### DIFF
--- a/internal/validators/privileges/role_privilege_test.go
+++ b/internal/validators/privileges/role_privilege_test.go
@@ -94,3 +94,52 @@ func TestRolePrivilegeValidationService_ReconcileRolePrivilegesRule(t *testing.T
 		util.CheckTestCase(t, vr, tc.expectedResult, err, tc.expectedErr)
 	}
 }
+
+func TestIsSameUser(t *testing.T) {
+	testCases := []struct {
+		name          string
+		userPrincipal string
+		username      string
+		expected      bool
+	}{
+		{
+			name:          "Valid match",
+			userPrincipal: "VSPHERE.LOCAL\\username",
+			username:      "username@vsphere.local",
+			expected:      true,
+		},
+		{
+			name:          "Different usernames",
+			userPrincipal: "VSPHERE.LOCAL\\username",
+			username:      "differentUsername@vsphere.local",
+			expected:      false,
+		},
+		{
+			name:          "Different domain",
+			userPrincipal: "VSPHERE.LOCAL\\username",
+			username:      "username@vsphere.notlocal",
+			expected:      false,
+		},
+		{
+			name:          "Invalid input - missing domain",
+			userPrincipal: "VSPHERE.LOCAL\\username",
+			username:      "username",
+			expected:      false,
+		},
+		{
+			name:          "Invalid input - missing username",
+			userPrincipal: "VSPHERE.LOCAL\\",
+			username:      "username@vsphere.local",
+			expected:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isSameUser(tc.userPrincipal, tc.username)
+			if result != tc.expected {
+				t.Errorf("Expected %v but got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/internal/validators/privileges/role_privilege_test.go
+++ b/internal/validators/privileges/role_privilege_test.go
@@ -28,9 +28,13 @@ func TestRolePrivilegeValidationService_ReconcileRolePrivilegesRule(t *testing.T
 
 	userPrivilegesMap["Cns.Searchable"] = true
 
-	// monkey-patch get user group and principals
+	// monkey-patch GetUserGroupAndPrincipals and IsAdminAccount
 	GetUserAndGroupPrincipals = func(ctx context.Context, username string, driver *vsphere.VSphereCloudDriver) (string, []string, error) {
 		return "admin", []string{"Administrators"}, nil
+	}
+
+	IsAdminAccount = func(ctx context.Context, driver *vsphere.VSphereCloudDriver) (bool, error) {
+		return true, nil
 	}
 
 	authManager := object.NewAuthorizationManager(vcSim.Driver.Client.Client)

--- a/internal/validators/privileges/role_privilege_test.go
+++ b/internal/validators/privileges/role_privilege_test.go
@@ -107,33 +107,33 @@ func TestIsSameUser(t *testing.T) {
 		expected      bool
 	}{
 		{
-			name:          "Valid match",
-			userPrincipal: "VSPHERE.LOCAL\\username",
-			username:      "username@vsphere.local",
+			name:          `Valid match`,
+			userPrincipal: `VSPHERE.LOCAL\username`,
+			username:      `username@vsphere.local`,
 			expected:      true,
 		},
 		{
-			name:          "Different usernames",
-			userPrincipal: "VSPHERE.LOCAL\\username",
-			username:      "differentUsername@vsphere.local",
+			name:          `Different usernames`,
+			userPrincipal: `VSPHERE.LOCAL\username`,
+			username:      `differentUsername@vsphere.local`,
 			expected:      false,
 		},
 		{
-			name:          "Different domain",
-			userPrincipal: "VSPHERE.LOCAL\\username",
-			username:      "username@vsphere.notlocal",
+			name:          `Different domain`,
+			userPrincipal: `VSPHERE.LOCAL\username`,
+			username:      `username@vsphere.notlocal`,
 			expected:      false,
 		},
 		{
-			name:          "Invalid input - missing domain",
-			userPrincipal: "VSPHERE.LOCAL\\username",
-			username:      "username",
+			name:          `Invalid input - missing domain`,
+			userPrincipal: `VSPHERE.LOCAL\username`,
+			username:      `username`,
 			expected:      false,
 		},
 		{
-			name:          "Invalid input - missing username",
-			userPrincipal: "VSPHERE.LOCAL\\",
-			username:      "username@vsphere.local",
+			name:          `Invalid input - missing username`,
+			userPrincipal: `VSPHERE.LOCAL\`,
+			username:      `username@vsphere.local`,
 			expected:      false,
 		},
 	}

--- a/internal/validators/privileges/role_privileges.go
+++ b/internal/validators/privileges/role_privileges.go
@@ -179,7 +179,7 @@ func getPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver, auth
 // checks if a user principle (VSPHERE.LOCAL\username) matches the username (username@vsphere.local)
 // it is only considered a match if the usernames on both are identical and the domains match
 func isSameUser(userPrincipal string, username string) bool {
-	userPrincipalParts := strings.Split(userPrincipal, "\\")
+	userPrincipalParts := strings.Split(userPrincipal, `\`)
 	usernameParts := strings.Split(username, "@")
 
 	if len(userPrincipalParts) != 2 || len(usernameParts) != 2 {
@@ -214,23 +214,4 @@ func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsp
 	userPrincipal := fmt.Sprintf("%s\\%s", strings.ToUpper(user.Id.Domain), user.Id.Name)
 
 	return userPrincipal, groups, nil
-}
-
-func getAccountPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver) (map[string]bool, error) {
-	authManager := object.NewAuthorizationManager(driver.Client.Client)
-	if authManager == nil {
-		return nil, fmt.Errorf("Error getting authorization manager")
-	}
-
-	userName, err := driver.GetCurrentVmwareUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	userPrivileges, err := vsphere.GetVmwareUserPrivileges(ctx, userName, []string{}, authManager)
-	if err != nil {
-		return nil, err
-	}
-
-	return userPrivileges, nil
 }

--- a/internal/validators/privileges/role_privileges.go
+++ b/internal/validators/privileges/role_privileges.go
@@ -80,9 +80,8 @@ func isValidRule(privilege string, privileges map[string]bool) bool {
 	return privileges[privilege]
 }
 
-func configureSSOClient(driver *vsphere.VSphereCloudDriver) (*ssoadmin.Client, error) {
+func configureSSOClient(ctx context.Context, driver *vsphere.VSphereCloudDriver) (*ssoadmin.Client, error) {
 	vc := driver.Client.Client
-	ctx := context.Background()
 	ssoClient, err := ssoadmin.NewClient(ctx, vc)
 	if err != nil {
 		return nil, err
@@ -121,7 +120,7 @@ func configureSSOClient(driver *vsphere.VSphereCloudDriver) (*ssoadmin.Client, e
 }
 
 func isAdminAccount(ctx context.Context, driver *vsphere.VSphereCloudDriver) (bool, error) {
-	ssoClient, err := configureSSOClient(driver)
+	ssoClient, err := configureSSOClient(ctx, driver)
 	defer ssoClient.Logout(ctx)
 
 	_, err = ssoClient.FindUser(ctx, driver.VCenterUsername)
@@ -189,7 +188,7 @@ func isSameUser(userPrincipal string, username string) bool {
 func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsphere.VSphereCloudDriver) (string, []string, error) {
 	var groups []string
 
-	ssoClient, err := configureSSOClient(driver)
+	ssoClient, err := configureSSOClient(ctx, driver)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/validators/privileges/role_privileges.go
+++ b/internal/validators/privileges/role_privileges.go
@@ -144,19 +144,13 @@ func getPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver, auth
 		return nil, err
 	}
 
-	groupPrincipals := make([]string, 0)
 	if isAdmin {
 		userPrincipal, groupPrincipals, err := GetUserAndGroupPrincipals(ctx, username, driver)
 		if err != nil {
 			return nil, err
 		}
 
-		privileges, err := vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
-		if err != nil {
-			return nil, err
-		}
-
-		return privileges, nil
+		return vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
 	}
 
 	userPrincipal, err := driver.GetCurrentVmwareUser(ctx)
@@ -168,12 +162,8 @@ func getPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver, auth
 		return nil, errors.New("Not authorized to get privileges for another user from non-admin account")
 	}
 
-	privileges, err := vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
-	if err != nil {
-		return nil, err
-	}
-
-	return privileges, nil
+	groupPrincipals := make([]string, 0)
+	return vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
 }
 
 // checks if a user principle (VSPHERE.LOCAL\username) matches the username (username@vsphere.local)

--- a/internal/validators/privileges/role_privileges.go
+++ b/internal/validators/privileges/role_privileges.go
@@ -52,18 +52,11 @@ func (s *PrivilegeValidationService) ReconcileRolePrivilegesRule(rule v1alpha1.G
 	defer cancel()
 
 	vr := buildValidationResult(rule, constants.ValidationTypeRolePrivileges)
-
 	failMsg := fmt.Sprintf("One or more required privileges was not found, or a condition was not met for account: %s", rule.Username)
-	userPrincipal, groupPrincipals, err := GetUserAndGroupPrincipals(ctx, rule.Username, driver)
-	if err != nil {
-		vr.Condition.Failures = append(vr.Condition.Failures, fmt.Sprintf("Failed to get user and group principles due to error: %s", err))
-		setFailureStatus(vr, failMsg)
-		return vr, err
-	}
 
-	privileges, err := vsphere.GetVmwareUserPrivileges(userPrincipal, groupPrincipals, authManager)
+	privileges, err := getPrivileges(ctx, driver, authManager, rule.Username)
 	if err != nil {
-		vr.Condition.Failures = append(vr.Condition.Failures, fmt.Sprintf("Failed to get VMWare user priviliges due to error: %s", err))
+		vr.Condition.Failures = append(vr.Condition.Failures, fmt.Sprintf("Failed to get user privileges for %s due to error: %s", rule.Username, err))
 		setFailureStatus(vr, failMsg)
 		return vr, err
 	}
@@ -87,13 +80,12 @@ func isValidRule(privilege string, privileges map[string]bool) bool {
 	return privileges[privilege]
 }
 
-func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsphere.VSphereCloudDriver) (string, []string, error) {
-	var groups []string
+func configureSSOClient(driver *vsphere.VSphereCloudDriver) (*ssoadmin.Client, error) {
 	vc := driver.Client.Client
-
+	ctx := context.Background()
 	ssoClient, err := ssoadmin.NewClient(ctx, vc)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	token := os.Getenv("SSO_LOGIN_TOKEN")
@@ -106,7 +98,7 @@ func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsp
 	if token == "" {
 		tokens, cerr := sts.NewClient(ctx, vc)
 		if cerr != nil {
-			return "", nil, cerr
+			return nil, cerr
 		}
 
 		userInfo := url.UserPassword(driver.VCenterUsername, driver.VCenterPassword)
@@ -117,11 +109,88 @@ func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsp
 
 		header.Security, cerr = tokens.Issue(ctx, req)
 		if cerr != nil {
-			return "", nil, cerr
+			return nil, cerr
 		}
 	}
 
 	if err = ssoClient.Login(ssoClient.WithHeader(ctx, header)); err != nil {
+		return nil, err
+	}
+
+	return ssoClient, nil
+}
+
+func isAdminAccount(ctx context.Context, driver *vsphere.VSphereCloudDriver) (bool, error) {
+	ssoClient, err := configureSSOClient(driver)
+	defer ssoClient.Logout(ctx)
+
+	_, err = ssoClient.FindUser(ctx, driver.VCenterUsername)
+	if err != nil {
+		if strings.Contains(err.Error(), "NoPermission") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func getPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver, authManager *object.AuthorizationManager, username string) (map[string]bool, error) {
+	isAdmin, err := isAdminAccount(ctx, driver)
+	if err != nil {
+		return nil, err
+	}
+
+	groupPrincipals := make([]string, 0)
+	if isAdmin {
+		userPrincipal, groupPrincipals, err := GetUserAndGroupPrincipals(ctx, username, driver)
+		if err != nil {
+			return nil, err
+		}
+
+		privileges, err := vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
+		if err != nil {
+			return nil, err
+		}
+
+		return privileges, nil
+	}
+
+	userPrincipal, err := driver.GetCurrentVmwareUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isSameUser(userPrincipal, username) {
+		return nil, errors.New("Not authorized to get privileges for another user from non-admin account")
+	}
+
+	privileges, err := vsphere.GetVmwareUserPrivileges(ctx, userPrincipal, groupPrincipals, authManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return privileges, nil
+}
+
+// checks if a user principle (VSPHERE.LOCAL\username) matches the username (username@vsphere.local)
+// it is only considered a match if the usernames on both are identical and the domains match
+func isSameUser(userPrincipal string, username string) bool {
+	userPrincipalParts := strings.Split(userPrincipal, "\\")
+	usernameParts := strings.Split(username, "@")
+
+	if len(userPrincipalParts) != 2 || len(usernameParts) != 2 {
+		return false
+	}
+
+	return strings.ToLower(userPrincipalParts[0]) == strings.ToLower(usernameParts[1]) && userPrincipalParts[1] == usernameParts[0]
+}
+
+func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsphere.VSphereCloudDriver) (string, []string, error) {
+	var groups []string
+
+	ssoClient, err := configureSSOClient(driver)
+	if err != nil {
 		return "", nil, err
 	}
 	defer ssoClient.Logout(ctx)
@@ -142,4 +211,23 @@ func getUserAndGroupPrincipals(ctx context.Context, username string, driver *vsp
 	userPrincipal := fmt.Sprintf("%s\\%s", strings.ToUpper(user.Id.Domain), user.Id.Name)
 
 	return userPrincipal, groups, nil
+}
+
+func getAccountPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver) (map[string]bool, error) {
+	authManager := object.NewAuthorizationManager(driver.Client.Client)
+	if authManager == nil {
+		return nil, fmt.Errorf("Error getting authorization manager")
+	}
+
+	userName, err := driver.GetCurrentVmwareUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	userPrivileges, err := vsphere.GetVmwareUserPrivileges(ctx, userName, []string{}, authManager)
+	if err != nil {
+		return nil, err
+	}
+
+	return userPrivileges, nil
 }

--- a/internal/validators/privileges/role_privileges.go
+++ b/internal/validators/privileges/role_privileges.go
@@ -24,6 +24,7 @@ import (
 )
 
 var (
+	IsAdminAccount                    = isAdminAccount
 	GetUserAndGroupPrincipals         = getUserAndGroupPrincipals
 	ErrRequiredRolePrivilegesNotFound = errors.New("one or more required role privileges was not found for account")
 )
@@ -121,6 +122,9 @@ func configureSSOClient(ctx context.Context, driver *vsphere.VSphereCloudDriver)
 
 func isAdminAccount(ctx context.Context, driver *vsphere.VSphereCloudDriver) (bool, error) {
 	ssoClient, err := configureSSOClient(ctx, driver)
+	if err != nil {
+		return false, err
+	}
 	defer ssoClient.Logout(ctx)
 
 	_, err = ssoClient.FindUser(ctx, driver.VCenterUsername)
@@ -135,7 +139,7 @@ func isAdminAccount(ctx context.Context, driver *vsphere.VSphereCloudDriver) (bo
 }
 
 func getPrivileges(ctx context.Context, driver *vsphere.VSphereCloudDriver, authManager *object.AuthorizationManager, username string) (map[string]bool, error) {
-	isAdmin, err := isAdminAccount(ctx, driver)
+	isAdmin, err := IsAdminAccount(ctx, driver)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vsphere/vsphere.go
+++ b/pkg/vsphere/vsphere.go
@@ -324,7 +324,7 @@ func (v *VSphereCloudDriver) CreateVSphereVMFolder(ctx context.Context, datacent
 }
 
 func (v *VSphereCloudDriver) getFinderWithDatacenter(ctx context.Context, datacenter string) (*find.Finder, string, error) {
-	finder, err := v.getFinder(ctx)
+	finder, err := v.getFinder()
 	if err != nil {
 		return nil, "", err
 	}
@@ -338,7 +338,7 @@ func (v *VSphereCloudDriver) getFinderWithDatacenter(ctx context.Context, datace
 	return finder, dc.Name(), nil
 }
 
-func (v *VSphereCloudDriver) getFinder(ctx context.Context) (*find.Finder, error) {
+func (v *VSphereCloudDriver) getFinder() (*find.Finder, error) {
 	if v.Client == nil {
 		return nil, fmt.Errorf("failed to fetch govmomi client: %d", http.StatusBadRequest)
 	}
@@ -385,7 +385,7 @@ func (v *VSphereCloudDriver) GetFolderNameByID(ctx context.Context, datacenter, 
 }
 
 func (v *VSphereCloudDriver) GetFinderWithDatacenter(ctx context.Context, datacenter string) (*find.Finder, string, error) {
-	finder, err := v.getFinder(ctx)
+	finder, err := v.getFinder()
 	if err != nil {
 		return nil, "", err
 	}
@@ -399,14 +399,14 @@ func (v *VSphereCloudDriver) GetFinderWithDatacenter(ctx context.Context, datace
 	return finder, dc.Name(), nil
 }
 
-func GetVmwareUserPrivileges(userPrincipal string, groupPrincipals []string, authManager *object.AuthorizationManager) (map[string]bool, error) {
+func GetVmwareUserPrivileges(ctx context.Context, userPrincipal string, groupPrincipals []string, authManager *object.AuthorizationManager) (map[string]bool, error) {
 	groupPrincipalMap := make(map[string]bool)
 	for _, principal := range groupPrincipals {
 		groupPrincipalMap[principal] = true
 	}
 
 	// Get the current user's roles
-	authRoles, err := authManager.RoleList(context.TODO())
+	authRoles, err := authManager.RoleList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +417,7 @@ func GetVmwareUserPrivileges(userPrincipal string, groupPrincipals []string, aut
 	// Print the roles
 	for _, authRole := range authRoles {
 		// print permissions for every role
-		permissions, err := authManager.RetrieveRolePermissions(context.TODO(), authRole.RoleId)
+		permissions, err := authManager.RetrieveRolePermissions(ctx, authRole.RoleId)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Once this is in, we'll officially support the following:
1. an admin account running role privilege rules for any other account (previously supported as well)
2. a non admin account running role privilege rules for their own account