### PR TITLE
chore: ensure that VSphereCloudDriver implements the VsphereDriver interface

### DIFF
--- a/pkg/vsphere/vsphere.go
+++ b/pkg/vsphere/vsphere.go
@@ -50,6 +50,9 @@ type VsphereDriver interface {
 	GetResourceTags(ctx context.Context, resourceType string) (map[string]tags.AttachedTags, error)
 }
 
+// ensure that VSphereCloudDriver implements the VsphereDriver interface
+var _ VsphereDriver = &VSphereCloudDriver{}
+
 type VSphereCloudDriver struct {
 	VCenterServer   string
 	VCenterUsername string

--- a/pkg/vsphere/vsphere_mocks.go
+++ b/pkg/vsphere/vsphere_mocks.go
@@ -20,6 +20,9 @@ type MockVsphereDriver struct {
 	ResourceTags       map[string]tags.AttachedTags
 }
 
+// ensure that MockVsphereDriver implements the VsphereDriver interface
+var _ VsphereDriver = &MockVsphereDriver{}
+
 func (d MockVsphereDriver) GetVSphereVMFolders(ctx context.Context, datacenter string) ([]string, error) {
 	return d.VMFolders, nil
 }


### PR DESCRIPTION
## Description
Small quality of life change to ensure our VSphereCloudDriver and MockVsphereDriver both always implement the VsphereDriver interface
