### PR TITLE
chore: ensure that VSphereCloudDriver has IsAdminAccount function

### DIFF
--- a/pkg/vsphere/user.go
+++ b/pkg/vsphere/user.go
@@ -102,6 +102,10 @@ func (v *VSphereCloudDriver) ValidateUserPrivilegeOnEntities(ctx context.Context
 	return isValid, failures, nil
 }
 
+func (v *VSphereCloudDriver) IsAdminAccount(ctx context.Context) (bool, error) {
+	return IsAdminAccount(ctx, v)
+}
+
 func GetVmwareUserPrivileges(ctx context.Context, userPrincipal string, groupPrincipals []string, authManager *object.AuthorizationManager) (map[string]bool, error) {
 	groupPrincipalMap := make(map[string]bool)
 	for _, principal := range groupPrincipals {

--- a/pkg/vsphere/vsphere.go
+++ b/pkg/vsphere/vsphere.go
@@ -48,6 +48,7 @@ type VsphereDriver interface {
 	GetResourcePools(ctx context.Context, datacenter string, cluster string) ([]*object.ResourcePool, error)
 	GetVapps(ctx context.Context) ([]mo.VirtualApp, error)
 	GetResourceTags(ctx context.Context, resourceType string) (map[string]tags.AttachedTags, error)
+	IsAdminAccount(ctx context.Context) (bool, error)
 }
 
 // ensure that VSphereCloudDriver implements the VsphereDriver interface

--- a/pkg/vsphere/vsphere_mocks.go
+++ b/pkg/vsphere/vsphere_mocks.go
@@ -67,6 +67,10 @@ func (d MockVsphereDriver) GetResourceTags(ctx context.Context, resourceType str
 	return d.ResourceTags, nil
 }
 
+func (d MockVsphereDriver) IsAdminAccount(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
 func concat(ss ...string) string {
 	return strings.Join(ss, "_")
 }


### PR DESCRIPTION
## Description
This adds the IsAdminAccount function to the VsphereDriver interface to make using the function simpler. This is to avoid potentially needing type assertions when calling IsAdminAccount
