### PR TITLE
fix: deduplicate resource rule scope to prevent resource overflow

### DIFF
--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:alpine3.18 as builder
+FROM --platform=$TARGETPLATFORM golang:alpine3.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,16 @@ make undeploy
 ```
 
 ## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
+All contributions are welcome! Feel free to reach out on the [Spectro Cloud community Slack](https://spectrocloudcommunity.slack.com/join/shared_invite/zt-g8gfzrhf-cKavsGD_myOh30K24pImLA#/shared-invite/email).
+
+Make sure `pre-commit` is [installed](https://pre-commit.com#install).
+
+Install the `pre-commit` scripts:
+
+```console
+pre-commit install --hook-type commit-msg
+pre-commit install --hook-type pre-commit
+```
 
 ### How it works
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -113,13 +113,16 @@ func Validate(ctx context.Context, spec v1alpha1.VsphereValidatorSpec, vsphereAc
 
 	// Compute resource validation rules
 	computeResourceValidationService := computeresources.NewValidationService(log, driver)
+	seenScope := make(map[string]bool, 0)
 	for _, rule := range spec.ComputeResourceRules {
-		vrr, err := computeResourceValidationService.ReconcileComputeResourceValidationRule(rule, finder, driver)
+		vrr, err := computeResourceValidationService.ReconcileComputeResourceValidationRule(rule, finder, driver, seenScope)
 		if err != nil {
 			log.Error(err, "failed to reconcile computeresources validation rule")
 		}
 		resp.AddResult(vrr, err)
 		log.Info("Validated compute resources", "scope", rule.Scope, "entity name", rule.EntityName)
+		key := computeresources.GetScopeKey(rule)
+		seenScope[key] = true
 	}
 
 	return resp


### PR DESCRIPTION
## Issue
Resolves  #306 

## Description
If the same scope is used in 2 or more resource validation rules, all rules after the 1st will automatically fail. The goal is to prevent potentially reusing the same set of resources to validate 2 rules.

Two unit tests have been added to check for various cluster/scope combos.