### PR TITLE
fix: YAML rendering of structs embedded in rules

### DIFF
--- a/api/v1alpha1/vspherevalidator_types.go
+++ b/api/v1alpha1/vspherevalidator_types.go
@@ -46,7 +46,7 @@ type VsphereAuth struct {
 
 // NTPValidationRule defines the NTP validation rule
 type NTPValidationRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// RuleName is the name of the NTP validation rule
 	RuleName string `json:"name" yaml:"name"`
@@ -70,7 +70,7 @@ func (r *NTPValidationRule) SetName(name string) {
 
 // ComputeResourceRule defines the compute resource validation rule
 type ComputeResourceRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// RuleName is the name of the compute resource validation rule
 	RuleName string `json:"name" yaml:"name"`
@@ -98,7 +98,7 @@ func (r *ComputeResourceRule) SetName(name string) {
 
 // EntityPrivilegeValidationRule defines the entity privilege validation rule
 type EntityPrivilegeValidationRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// RuleName is the name of the entity privilege validation rule
 	RuleName string `json:"name" yaml:"name"`
@@ -128,7 +128,7 @@ func (r *EntityPrivilegeValidationRule) SetName(name string) {
 
 // GenericRolePrivilegeValidationRule defines the generic role privilege validation rule
 type GenericRolePrivilegeValidationRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Username is the username to validate against
 	Username string `json:"username" yaml:"username"`
@@ -145,7 +145,7 @@ func (r GenericRolePrivilegeValidationRule) Name() string {
 
 // TagValidationRule defines the tag validation rule
 type TagValidationRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// RuleName is the name of the tag validation rule
 	RuleName string `json:"name" yaml:"name"`


### PR DESCRIPTION
## Description
In previous PRs, we made the plugin rules implement the new `validationrule.Interface` interface. We did not include YAML tags in rules to specify that the new field (`validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` depending on the rule) should not be included when the rules are rendered to YAML. The validatorctl CLI renders the rules to YAML as part of what it does, so this caused errors when validatorctl tried to apply validator CRDs it generated to its cluster.