### PR TITLE
refactor: make API entities strings

### DIFF
--- a/api/v1alpha1/vspherevalidator_types.go
+++ b/api/v1alpha1/vspherevalidator_types.go
@@ -9,7 +9,6 @@ import (
 	"github.com/validator-labs/validator/pkg/validationrule"
 
 	"github.com/validator-labs/validator-plugin-vsphere/api/vcenter"
-	"github.com/validator-labs/validator-plugin-vsphere/api/vcenter/entity"
 	"github.com/validator-labs/validator-plugin-vsphere/pkg/constants"
 )
 
@@ -82,7 +81,7 @@ type ComputeResourceRule struct {
 	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName"`
 
 	// Scope is the scope of the compute resource validation rule.
-	Scope entity.Entity `json:"scope" yaml:"scope"`
+	Scope string `json:"scope" yaml:"scope"`
 
 	// EntityName is the name of the entity to validate.
 	EntityName string `json:"entityName" yaml:"entityName"`
@@ -114,7 +113,7 @@ type PrivilegeValidationRule struct {
 	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 
 	// EntityType is the type of the vCenter entity to validate.
-	EntityType entity.Entity `json:"entityType" yaml:"entityType"`
+	EntityType string `json:"entityType" yaml:"entityType"`
 
 	// EntityName is the name of the vCenter entity to validate privileges on.
 	EntityName string `json:"entityName" yaml:"entityName"`
@@ -165,7 +164,7 @@ type TagValidationRule struct {
 	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName"`
 
 	// EntityType is the type of the vCenter entity to validate.
-	EntityType entity.Entity `json:"entityType" yaml:"entityType"`
+	EntityType string `json:"entityType" yaml:"entityType"`
 
 	// EntityName is the name of the vCenter entity to validate tags on.
 	EntityName string `json:"entityName" yaml:"entityName"`

--- a/api/vcenter/entity/entities_test.go
+++ b/api/vcenter/entity/entities_test.go
@@ -39,7 +39,7 @@ func TestMarshalYAML(t *testing.T) {
 	}
 }
 
-func TestUnMarshalYAML(t *testing.T) {
+func TestUnmarshalYAML(t *testing.T) {
 	// int
 	in := []byte("8\n")
 	expected := ResourcePool

--- a/chart/validator-plugin-vsphere/crds/validation.spectrocloud.labs_vspherevalidators.yaml
+++ b/chart/validator-plugin-vsphere/crds/validation.spectrocloud.labs_vspherevalidators.yaml
@@ -123,7 +123,7 @@ spec:
                     scope:
                       description: Scope is the scope of the compute resource validation
                         rule.
-                      type: integer
+                      type: string
                   required:
                   - entityName
                   - name
@@ -171,7 +171,7 @@ spec:
                     entityType:
                       description: EntityType is the type of the vCenter entity to
                         validate.
-                      type: integer
+                      type: string
                     name:
                       description: RuleName is the name of the privilege validation
                         rule.
@@ -230,7 +230,7 @@ spec:
                     entityType:
                       description: EntityType is the type of the vCenter entity to
                         validate.
-                      type: integer
+                      type: string
                     name:
                       description: RuleName is the name of the tag validation rule.
                       type: string

--- a/config/crd/bases/validation.spectrocloud.labs_vspherevalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_vspherevalidators.yaml
@@ -123,7 +123,7 @@ spec:
                     scope:
                       description: Scope is the scope of the compute resource validation
                         rule.
-                      type: integer
+                      type: string
                   required:
                   - entityName
                   - name
@@ -171,7 +171,7 @@ spec:
                     entityType:
                       description: EntityType is the type of the vCenter entity to
                         validate.
-                      type: integer
+                      type: string
                     name:
                       description: RuleName is the name of the privilege validation
                         rule.
@@ -230,7 +230,7 @@ spec:
                     entityType:
                       description: EntityType is the type of the vCenter entity to
                         validate.
-                      type: integer
+                      type: string
                     name:
                       description: RuleName is the name of the tag validation rule.
                       type: string

--- a/internal/controller/vspherevalidator_controller_test.go
+++ b/internal/controller/vspherevalidator_controller_test.go
@@ -49,7 +49,7 @@ var _ = Describe("VsphereValidator controller", Ordered, func() {
 			TagValidationRules: []v1alpha1.TagValidationRule{
 				{
 					RuleName:   "Datacenter k8s-region rule",
-					EntityType: entity.Datacenter,
+					EntityType: entity.Datacenter.String(),
 					EntityName: "Datacenter",
 					Tag:        "k8s-region",
 				},

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -158,7 +158,7 @@ func testRules(inputs []privilegeRuleInput) []v1alpha1.PrivilegeValidationRule {
 	for i, input := range inputs {
 		r := v1alpha1.PrivilegeValidationRule{
 			RuleName:   fmt.Sprintf("rule %d", i),
-			EntityType: input.EntityType,
+			EntityType: input.EntityType.String(),
 			EntityName: input.EntityName,
 			Privileges: input.Privileges,
 		}

--- a/pkg/validators/computeresources/computeresources.go
+++ b/pkg/validators/computeresources/computeresources.go
@@ -127,7 +127,7 @@ func (c *ValidationService) ReconcileComputeResourceValidationRule(rule v1alpha1
 	defer cancel()
 
 	var res *Usage
-	switch rule.Scope {
+	switch e := entity.Map[rule.Scope]; e {
 	case entity.Cluster:
 		res, err = clusterUsage(ctx, rule, finder)
 	case entity.ResourcePool:
@@ -371,7 +371,7 @@ func getTotalQuantity(quantity string, numberOfNodes int) resource.Quantity {
 // GetScopeKey returns a formatted key depending on the scope of a rule
 func GetScopeKey(rule v1alpha1.ComputeResourceRule) (string, error) {
 	var key string
-	switch rule.Scope {
+	switch e := entity.Map[rule.Scope]; e {
 	case entity.Cluster:
 		key = fmt.Sprintf("%s-%s", rule.Scope, rule.EntityName)
 	case entity.Host:

--- a/pkg/validators/computeresources/computeresources_test.go
+++ b/pkg/validators/computeresources/computeresources_test.go
@@ -47,7 +47,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resource Validation rule",
 				ClusterName: "DC0_C0",
-				Scope:       entity.Cluster,
+				Scope:       entity.Cluster.String(),
 				EntityName:  "DC0_C0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -82,7 +82,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resource Validation rule",
 				ClusterName: "DC0_C0",
-				Scope:       entity.Cluster,
+				Scope:       entity.Cluster.String(),
 				EntityName:  "DC0_C0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -117,7 +117,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resource Validation rule",
 				ClusterName: "DC0_C0",
-				Scope:       entity.Cluster,
+				Scope:       entity.Cluster.String(),
 				EntityName:  "DC0_C0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -152,7 +152,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resource Validation rule",
 				ClusterName: "DC0_C0",
-				Scope:       entity.Cluster,
+				Scope:       entity.Cluster.String(),
 				EntityName:  "DC0_C0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -186,7 +186,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Host - All Resources available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:   "Test Host Resource Validation rule",
-				Scope:      entity.Host,
+				Scope:      entity.Host.String(),
 				EntityName: "DC0_C0_H0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -220,7 +220,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Host CPU not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:   "Test Host Resource Validation rule",
-				Scope:      entity.Host,
+				Scope:      entity.Host.String(),
 				EntityName: "DC0_C0_H0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -254,7 +254,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Host Memory not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:   "Test Host Resource Validation rule",
-				Scope:      entity.Host,
+				Scope:      entity.Host.String(),
 				EntityName: "DC0_C0_H0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -288,7 +288,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Host Disk not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:   "Test Host Resource Validation rule",
-				Scope:      entity.Host,
+				Scope:      entity.Host.String(),
 				EntityName: "DC0_C0_H0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{
@@ -322,7 +322,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Resourcepool - All Resources available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Host Resource Validation rule",
-				Scope:       entity.ResourcePool,
+				Scope:       entity.ResourcePool.String(),
 				ClusterName: "DC0_C0",
 				EntityName:  "DC0_C0_RP0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
@@ -357,7 +357,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Resourcepool CPU not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Host Resource Validation rule",
-				Scope:       entity.ResourcePool,
+				Scope:       entity.ResourcePool.String(),
 				ClusterName: "DC0_C0",
 				EntityName:  "DC0_C0_RP0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
@@ -392,7 +392,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Resourcepool Memory not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resourcepool Resource Validation rule",
-				Scope:       entity.ResourcePool,
+				Scope:       entity.ResourcePool.String(),
 				ClusterName: "DC0_C0",
 				EntityName:  "DC0_C0_RP0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
@@ -427,7 +427,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Resourcepool Disk not available",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resourcepool Resource Validation rule",
-				Scope:       entity.ResourcePool,
+				Scope:       entity.ResourcePool.String(),
 				ClusterName: "DC0_C0",
 				EntityName:  "DC0_C0_RP0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
@@ -462,7 +462,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Duplicate scope resourcepool",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:    "Test Resourcepool Resource Validation rule",
-				Scope:       entity.ResourcePool,
+				Scope:       entity.ResourcePool.String(),
 				ClusterName: "DC0_C1",
 				EntityName:  "DC0_C1_RP0",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
@@ -497,7 +497,7 @@ func TestReconcileComputeResourceValidationRule(t *testing.T) {
 			name: "Duplicate scope cluster",
 			rule: v1alpha1.ComputeResourceRule{
 				RuleName:   "Test Resourcepool Resource Validation rule",
-				Scope:      entity.Cluster,
+				Scope:      entity.Cluster.String(),
 				EntityName: "DC0_C1",
 				NodepoolResourceRequirements: []v1alpha1.NodepoolResourceRequirement{
 					{

--- a/pkg/validators/privileges/privilege_test.go
+++ b/pkg/validators/privileges/privilege_test.go
@@ -63,7 +63,7 @@ func TestPrivilegeValidationService_ReconcilePrivilegeRule(t *testing.T) {
 			rule: v1alpha1.PrivilegeValidationRule{
 				RuleName:    "VirtualMachine.Config.AddExistingDisk",
 				ClusterName: opts.Cluster,
-				EntityType:  entity.Cluster,
+				EntityType:  entity.Cluster.String(),
 				EntityName:  opts.Cluster,
 				Privileges:  []string{"VirtualMachine.Config.AddExistingDisk"},
 				Propagation: v1alpha1.Propagation{
@@ -87,7 +87,7 @@ func TestPrivilegeValidationService_ReconcilePrivilegeRule(t *testing.T) {
 			rule: v1alpha1.PrivilegeValidationRule{
 				RuleName:    "VirtualMachine.Config.MagicCarpet",
 				ClusterName: opts.Cluster,
-				EntityType:  entity.Cluster,
+				EntityType:  entity.Cluster.String(),
 				EntityName:  opts.Cluster,
 				Privileges:  []string{"VirtualMachine.Config.MagicCarpet"},
 				Propagation: v1alpha1.Propagation{

--- a/pkg/validators/tags/tags.go
+++ b/pkg/validators/tags/tags.go
@@ -99,7 +99,7 @@ func tagIsValid(tagsManager *tags.Manager, finder *find.Finder, datacenter strin
 		}
 	}
 
-	switch rule.EntityType {
+	switch e := entity.Map[rule.EntityType]; e {
 	case entity.Cluster:
 		inventoryPath = fmt.Sprintf(vcenter.ClusterInventoryPath, datacenter, rule.EntityName)
 	case entity.Datacenter:

--- a/pkg/vsphere/user.go
+++ b/pkg/vsphere/user.go
@@ -111,7 +111,7 @@ func (v *VCenterDriver) ValidateUserPrivilegeOnEntities(ctx context.Context, aut
 func (v *VCenterDriver) getObjRef(ctx context.Context, datacenter string, finder *find.Finder, rule v1alpha1.PrivilegeValidationRule) (*types.ManagedObjectReference, error) {
 	var objRef types.ManagedObjectReference
 
-	switch rule.EntityType {
+	switch e := entity.Map[rule.EntityType]; e {
 	case entity.Cluster:
 		cluster, err := v.GetCluster(ctx, finder, datacenter, rule.EntityName)
 		if err != nil {

--- a/pkg/vsphere/user.go
+++ b/pkg/vsphere/user.go
@@ -143,7 +143,7 @@ func (v *VCenterDriver) getObjRef(ctx context.Context, datacenter string, finder
 		}
 		objRef = dvs.Common.Reference()
 	case entity.Folder:
-		folder, err := v.GetFolder(ctx, finder, rule.EntityName)
+		folder, err := v.GetFolder(ctx, datacenter, rule.EntityName)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/integration/tags/tags.go
+++ b/tests/integration/tags/tags.go
@@ -143,20 +143,20 @@ func (t *TagValidationTest) testTagsOnObjects(ctx *test.TestContext) (tr *test.T
 	rules := []v1alpha1.TagValidationRule{
 		{
 			RuleName:   "Datacenter validation rule",
-			EntityType: entity.Datacenter,
+			EntityType: entity.Datacenter.String(),
 			EntityName: "DC0",
 			Tag:        "k8s-region",
 		},
 		{
 			RuleName:   "Cluster validation rule",
-			EntityType: entity.Cluster,
+			EntityType: entity.Cluster.String(),
 			EntityName: "DC0_C0",
 			Tag:        "k8s-zone",
 		},
 		{
 			RuleName:    "Host validation rule",
 			ClusterName: "DC0_C0",
-			EntityType:  entity.Host,
+			EntityType:  entity.Host.String(),
 			EntityName:  "DC0_C0_H0",
 			Tag:         "owner",
 		},


### PR DESCRIPTION
## Issue
N/A

## Description
- Make API entities strings, otherwise the UX is terrible
- Scope GetFolder to a datacenter, trim the datacenter/vm prefix, and take the first item with the folder name as a prefix. This avoids selecting, e.g., `sp-pritam/spectro-templates` before the top-level `spectro-templates` folder.
