### PR TITLE
fix: metrics targetPort https -> 8443

### DIFF
--- a/chart/validator-plugin-vsphere/README.md
+++ b/chart/validator-plugin-vsphere/README.md
@@ -23,7 +23,7 @@ The following table lists the configurable parameters of the Validator-plugin-vs
 | `controllerManager.replicas` |  | `1` |
 | `controllerManager.serviceAccount.annotations` |  | `{}` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
-| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
+| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": 8443}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 
 

--- a/chart/validator-plugin-vsphere/values.yaml
+++ b/chart/validator-plugin-vsphere/values.yaml
@@ -28,5 +28,5 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP


### PR DESCRIPTION
Metrics server is exposed on port 8443. This PR updates the metrics service chart value to match this, to ensure it's accessible.
